### PR TITLE
Moved scripts to bottom of html

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,6 @@
 
   <link href="style/main.css" rel="stylesheet" type="text/css">
 
-  <script src="js/hammer.min.js"></script>
-  <script src="js/keyboard_input_manager.js"></script>
-  <script src="js/html_actuator.js"></script>
-  <script src="js/grid.js"></script>
-  <script src="js/tile.js"></script>
-  <script src="js/game_manager.js"></script>
-  <script src="js/application.js"></script>
-
   <meta name="HandheldFriendly" content="True">
   <meta name="MobileOptimized" content="320">
   <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0, maximum-scale=1, user-scalable=no">
@@ -74,5 +66,13 @@
       Created by <a href="http://gabrielecirulli.com" target="_blank">Gabriele Cirulli.</a> Based on <a href="https://itunes.apple.com/us/app/1024!/id823499224" target="_blank">1024 by Veewo Studio.</a>
     </p>
   </div>
+
+  <script src="js/hammer.min.js"></script>
+  <script src="js/keyboard_input_manager.js"></script>
+  <script src="js/html_actuator.js"></script>
+  <script src="js/grid.js"></script>
+  <script src="js/tile.js"></script>
+  <script src="js/game_manager.js"></script>
+  <script src="js/application.js"></script>
 </body>
 </html>

--- a/js/application.js
+++ b/js/application.js
@@ -1,6 +1,3 @@
-document.addEventListener("DOMContentLoaded", function () {
-  // Wait till the browser is ready to render the game (avoids glitches)
-  window.requestAnimationFrame(function () {
-    var manager = new GameManager(4, KeyboardInputManager, HTMLActuator);
-  });
+window.requestAnimationFrame(function () {
+  var manager = new GameManager(4, KeyboardInputManager, HTMLActuator);
 });


### PR DESCRIPTION
It's customary to put script tags before the closing body tag for loading/performance reasons (See [http://stackoverflow.com/questions/436411/where-is-the-best-place-to-put-script-tags-in-html-markup](StackOverflow)). 

You can also remove your `DOMContentLoaded` event listener since the DOM will be loaded by this point.
