### PR TITLE
allow rectangular grids

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,30 +28,7 @@
       </div>
 
       <div class="grid-container">
-        <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-        </div>
-        <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-        </div>
-        <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-        </div>
-        <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-        </div>
+
       </div>
 
       <div class="tile-container">

--- a/js/application.js
+++ b/js/application.js
@@ -1,4 +1,4 @@
 // Wait till the browser is ready to render the game (avoids glitches)
 window.requestAnimationFrame(function () {
-  var manager = new GameManager(4, KeyboardInputManager, HTMLActuator);
+  var manager = new GameManager(4, 4, KeyboardInputManager, HTMLActuator);
 });

--- a/js/game_manager.js
+++ b/js/game_manager.js
@@ -1,5 +1,6 @@
-function GameManager(size, InputManager, Actuator) {
-  this.size         = size; // Size of the grid
+function GameManager(sizeX, sizeY, InputManager, Actuator) {
+  this.sizeX         = sizeX; // Width of the grid
+  this.sizeY         = sizeY; // Height of the grid
   this.inputManager = new InputManager;
   this.actuator     = new Actuator;
 
@@ -19,11 +20,14 @@ GameManager.prototype.restart = function () {
 
 // Set up the game
 GameManager.prototype.setup = function () {
-  this.grid         = new Grid(this.size);
+  this.grid         = new Grid(this.sizeX, this.sizeY);
 
   this.score        = 0;
   this.over         = false;
   this.won          = false;
+
+  // Build the game grid
+  this.actuator.buildHTMLGrid(this.sizeX, this.sizeY);
 
   // Add the initial tiles
   this.addStartTiles();
@@ -70,8 +74,8 @@ GameManager.prototype.prepareTiles = function () {
 
 // Move a tile and its representation
 GameManager.prototype.moveTile = function (tile, cell) {
-  this.grid.cells[tile.x][tile.y] = null;
-  this.grid.cells[cell.x][cell.y] = tile;
+  this.grid.cells[tile.y][tile.x] = null;
+  this.grid.cells[cell.y][cell.x] = tile;
   tile.updatePosition(cell);
 };
 
@@ -92,8 +96,8 @@ GameManager.prototype.move = function (direction) {
   this.prepareTiles();
 
   // Traverse the grid in the right direction and move tiles
-  traversals.x.forEach(function (x) {
-    traversals.y.forEach(function (y) {
+  traversals.y.forEach(function (y) {
+    traversals.x.forEach(function (x) {
       cell = { x: x, y: y };
       tile = self.grid.cellContent(cell);
 
@@ -156,8 +160,10 @@ GameManager.prototype.getVector = function (direction) {
 GameManager.prototype.buildTraversals = function (vector) {
   var traversals = { x: [], y: [] };
 
-  for (var pos = 0; pos < this.size; pos++) {
+  for (var pos = 0; pos < this.sizeX; pos++) {
     traversals.x.push(pos);
+  }
+  for (var pos = 0; pos < this.sizeY; pos++) {
     traversals.y.push(pos);
   }
 
@@ -194,8 +200,8 @@ GameManager.prototype.tileMatchesAvailable = function () {
 
   var tile;
 
-  for (var x = 0; x < this.size; x++) {
-    for (var y = 0; y < this.size; y++) {
+  for (var y = 0; y < this.sizeY; y++) {
+    for (var x = 0; x < this.sizeX; x++) {
       tile = this.grid.cellContent({ x: x, y: y });
 
       if (tile) {

--- a/js/grid.js
+++ b/js/grid.js
@@ -1,5 +1,6 @@
-function Grid(size) {
-  this.size = size;
+function Grid(sizeX, sizeY) {
+  this.sizeX = sizeX;
+  this.sizeY = sizeY;
 
   this.cells = [];
 
@@ -8,10 +9,10 @@ function Grid(size) {
 
 // Build a grid of the specified size
 Grid.prototype.build = function () {
-  for (var x = 0; x < this.size; x++) {
-    var row = this.cells[x] = [];
+  for (var y = 0; y < this.sizeY; y++) {
+    var row = this.cells[y] = [];
 
-    for (var y = 0; y < this.size; y++) {
+    for (var x = 0; x < this.sizeX; x++) {
       row.push(null);
     }
   }
@@ -40,9 +41,9 @@ Grid.prototype.availableCells = function () {
 
 // Call callback for every cell
 Grid.prototype.eachCell = function (callback) {
-  for (var x = 0; x < this.size; x++) {
-    for (var y = 0; y < this.size; y++) {
-      callback(x, y, this.cells[x][y]);
+  for (var y = 0; y < this.sizeY; y++) {
+    for (var x = 0; x < this.sizeX; x++) {
+      callback(x, y, this.cells[y][x]);
     }
   }
 };
@@ -63,7 +64,7 @@ Grid.prototype.cellOccupied = function (cell) {
 
 Grid.prototype.cellContent = function (cell) {
   if (this.withinBounds(cell)) {
-    return this.cells[cell.x][cell.y];
+    return this.cells[cell.y][cell.x];
   } else {
     return null;
   }
@@ -71,14 +72,14 @@ Grid.prototype.cellContent = function (cell) {
 
 // Inserts a tile at its position
 Grid.prototype.insertTile = function (tile) {
-  this.cells[tile.x][tile.y] = tile;
+  this.cells[tile.y][tile.x] = tile;
 };
 
 Grid.prototype.removeTile = function (tile) {
-  this.cells[tile.x][tile.y] = null;
+  this.cells[tile.y][tile.x] = null;
 };
 
 Grid.prototype.withinBounds = function (position) {
-  return position.x >= 0 && position.x < this.size &&
-         position.y >= 0 && position.y < this.size;
+  return position.x >= 0 && position.x < this.sizeX &&
+         position.y >= 0 && position.y < this.sizeY;
 };

--- a/js/html_actuator.js
+++ b/js/html_actuator.js
@@ -1,10 +1,25 @@
 function HTMLActuator() {
   this.tileContainer    = document.getElementsByClassName("tile-container")[0];
+  this.gridContainer    = document.getElementsByClassName("grid-container")[0];
   this.scoreContainer   = document.getElementsByClassName("score-container")[0];
   this.messageContainer = document.getElementsByClassName("game-message")[0];
 
   this.score = 0;
 }
+
+HTMLActuator.prototype.buildHTMLGrid = function (sizeX, sizeY) {
+  for (var y = 0; y < sizeY; y++) {
+    var row = document.createElement("div");
+    row.className = "grid-row";
+
+    for (var x = 0; x < sizeX; x++) {
+      var cell = document.createElement("div");
+      cell.className = "grid-cell";
+      row.appendChild(cell);
+    }
+    this.gridContainer.appendChild(row);
+  }
+};
 
 HTMLActuator.prototype.actuate = function (grid, metadata) {
   var self = this;
@@ -83,7 +98,7 @@ HTMLActuator.prototype.normalizePosition = function (position) {
 
 HTMLActuator.prototype.positionClass = function (position) {
   position = this.normalizePosition(position);
-  return "tile-position-" + position.x + "-" + position.y;
+  return "tile-position-" + position.y + "-" + position.x;
 };
 
 HTMLActuator.prototype.updateScore = function (score) {

--- a/style/main.css
+++ b/style/main.css
@@ -224,60 +224,60 @@ hr {
     top: 0px; }
   .tile.tile-position-1-2 {
     position: absolute;
-    left: 0px;
-    top: 121px; }
-  .tile.tile-position-1-3 {
-    position: absolute;
-    left: 0px;
-    top: 243px; }
-  .tile.tile-position-1-4 {
-    position: absolute;
-    left: 0px;
-    top: 364px; }
-  .tile.tile-position-2-1 {
-    position: absolute;
     left: 121px;
     top: 0px; }
+  .tile.tile-position-1-3 {
+    position: absolute;
+    left: 243px;
+    top: 0px; }
+  .tile.tile-position-1-4 {
+    position: absolute;
+    left: 364px;
+    top: 0px; }
+  .tile.tile-position-2-1 {
+    position: absolute;
+    left: 0px;
+    top: 121px; }
   .tile.tile-position-2-2 {
     position: absolute;
     left: 121px;
     top: 121px; }
   .tile.tile-position-2-3 {
     position: absolute;
-    left: 121px;
-    top: 243px; }
-  .tile.tile-position-2-4 {
-    position: absolute;
-    left: 121px;
-    top: 364px; }
-  .tile.tile-position-3-1 {
-    position: absolute;
-    left: 243px;
-    top: 0px; }
-  .tile.tile-position-3-2 {
-    position: absolute;
     left: 243px;
     top: 121px; }
+  .tile.tile-position-2-4 {
+    position: absolute;
+    left: 364px;
+    top: 121px; }
+  .tile.tile-position-3-1 {
+    position: absolute;
+    left: 0px;
+    top: 243px; }
+  .tile.tile-position-3-2 {
+    position: absolute;
+    left: 121px;
+    top: 243px; }
   .tile.tile-position-3-3 {
     position: absolute;
     left: 243px;
     top: 243px; }
   .tile.tile-position-3-4 {
     position: absolute;
-    left: 243px;
-    top: 364px; }
-  .tile.tile-position-4-1 {
-    position: absolute;
-    left: 364px;
-    top: 0px; }
-  .tile.tile-position-4-2 {
-    position: absolute;
-    left: 364px;
-    top: 121px; }
-  .tile.tile-position-4-3 {
-    position: absolute;
     left: 364px;
     top: 243px; }
+  .tile.tile-position-4-1 {
+    position: absolute;
+    left: 0px;
+    top: 364px; }
+  .tile.tile-position-4-2 {
+    position: absolute;
+    left: 121px;
+    top: 364px; }
+  .tile.tile-position-4-3 {
+    position: absolute;
+    left: 243px;
+    top: 364px; }
   .tile.tile-position-4-4 {
     position: absolute;
     left: 364px;
@@ -548,60 +548,59 @@ hr {
       top: 0px; }
     .tile.tile-position-1-2 {
       position: absolute;
-      left: 0px;
-      top: 68px; }
-    .tile.tile-position-1-3 {
-      position: absolute;
-      left: 0px;
-      top: 135px; }
-    .tile.tile-position-1-4 {
-      position: absolute;
-      left: 0px;
-      top: 203px; }
-    .tile.tile-position-2-1 {
-      position: absolute;
       left: 68px;
       top: 0px; }
+    .tile.tile-position-1-3 {
+      position: absolute;
+      left: 135px;
+      top: 0px; }
+    .tile.tile-position-1-4 {
+      position: absolute;
+      left: 203px;
+      top: 0px; }
+    .tile.tile-position-2-1 {
+      position: absolute;
+      left: 0px;
+      top: 68px; }
     .tile.tile-position-2-2 {
       position: absolute;
       left: 68px;
       top: 68px; }
     .tile.tile-position-2-3 {
       position: absolute;
-      left: 68px;
-      top: 135px; }
-    .tile.tile-position-2-4 {
-      position: absolute;
-      left: 68px;
-      top: 203px; }
-    .tile.tile-position-3-1 {
-      position: absolute;
-      left: 135px;
-      top: 0px; }
-    .tile.tile-position-3-2 {
-      position: absolute;
       left: 135px;
       top: 68px; }
+    .tile.tile-position-2-4 {
+      position: absolute;
+      left: 203px;
+      top: 68px; }
+    .tile.tile-position-3-1 {
+      position: absolute;
+      left: 0px;
+      top: 135px; }
+    .tile.tile-position-3-2 {
+      position: absolute;
+      left: 68px;
+      top: 135px; }
     .tile.tile-position-3-3 {
       position: absolute;
       left: 135px;
       top: 135px; }
     .tile.tile-position-3-4 {
       position: absolute;
-      left: 135px;
-      top: 203px; }
-    .tile.tile-position-4-1 {
-      position: absolute;
-      left: 203px;
-      top: 0px; }
-    .tile.tile-position-4-2 {
-      position: absolute;
-      left: 203px;
-      top: 68px; }
-    .tile.tile-position-4-3 {
-      position: absolute;
       left: 203px;
       top: 135px; }
+    .tile.tile-position-4-1 {
+      position: absolute;
+      left: 0px;
+      top: 203px; }
+    .tile.tile-position-4-2 {
+      position: absolute;
+      left: 68px;
+    .tile.tile-position-4-3 {
+      position: absolute;
+      left: 135px;
+      top: 203px; }
     .tile.tile-position-4-4 {
       position: absolute;
       left: 203px;

--- a/style/main.scss
+++ b/style/main.scss
@@ -3,8 +3,10 @@
 
 $field-width: 500px;
 $grid-spacing: 15px;
+$grid-rows: 4;
 $grid-row-cells: 4;
 $tile-size: ($field-width - $grid-spacing * ($grid-row-cells + 1)) / $grid-row-cells;
+$field-height: ($field-width - $grid-spacing) / $grid-row-cells * $grid-rows + $grid-spacing;
 $tile-border-radius: 3px;
 
 $text-color: #776E65;
@@ -168,7 +170,7 @@ hr {
     background: $game-container-background;
     border-radius: $tile-border-radius * 2;
     width: $field-width;
-    height: $field-width;
+    height: $field-height;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -266,9 +268,9 @@ hr {
     line-height: $tile-size + 10px;
 
     // Build position classes
-    @for $x from 1 through $grid-row-cells {
-      @for $y from 1 through $grid-row-cells {
-        &.tile-position-#{$x}-#{$y} {
+    @for $y from 1 through $grid-rows {
+      @for $x from 1 through $grid-row-cells {
+        &.tile-position-#{$y}-#{$x} {
           position: absolute;
           left: round(($tile-size + $grid-spacing) * ($x - 1));
           top: round(($tile-size + $grid-spacing) * ($y - 1));
@@ -419,8 +421,8 @@ hr {
   // Redefine variables for smaller screens
   $field-width: 280px;
   $grid-spacing: 10px;
-  $grid-row-cells: 4;
   $tile-size: ($field-width - $grid-spacing * ($grid-row-cells + 1)) / $grid-row-cells;
+  $field-height: ($field-width - $grid-spacing) / $grid-row-cells * $grid-rows + $grid-spacing;
   $tile-border-radius: 3px;
 
   html, body {


### PR DESCRIPTION
This patch allows the game to be played with grids that are rectangular instead of square. The size has to be changed in application.js and main.scss, and then main.css re-generated. Changing the height works well. Changing the width works less well, but still works.

This is actually a preparatory patch to a different modification that I want to make, which requires this and other functionality from the grid and tile types.
