### PR TITLE
Fix undefined best score

### DIFF
--- a/js/local_score_manager.js
+++ b/js/local_score_manager.js
@@ -26,7 +26,11 @@ function LocalScoreManager() {
 }
 
 LocalScoreManager.prototype.get = function () {
-  return this.storage.getItem(this.key) || 0;
+  var score = this.storage.getItem(this.key);
+  if (typeof score === "undefined" || score === null) {
+    score = 0;
+  }
+  return score;
 };
 
 LocalScoreManager.prototype.set = function (score) {


### PR DESCRIPTION
Revert "small change in scoremanager"
This reverts commit 88278792be80739c303968d2e4ff31a4eba317b6.

In javascript, `"undefined"` is evaluated as `true`.

``` js
"undefined" || 0 // => "undefined"
```
