### PR TITLE
Ensure the Try Again button actually disappears when selected in IE

### DIFF
--- a/js/html_actuator.js
+++ b/js/html_actuator.js
@@ -114,5 +114,7 @@ HTMLActuator.prototype.message = function (won) {
 };
 
 HTMLActuator.prototype.clearMessage = function () {
-  this.messageContainer.classList.remove("game-won", "game-over");
+  // IE only takes one value to remove at a time.
+  this.messageContainer.classList.remove("game-won");
+  this.messageContainer.classList.remove("game-over");
 };


### PR DESCRIPTION
This is to address issue https://github.com/gabrielecirulli/2048/issues/36. Its a relatively simple fix in which apparently Blink is the only one to implement classList.remove accepting multiple tokens (at least per http://html5doctor.com/the-classlist-api/ ). Everyone else wants individual calls to classList.remove.
