### PR TITLE
Added resuming of game from localstorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       </div>
     </div>
     <p class="game-intro">Join the numbers and get to the <strong>2048 tile!</strong></p>
-
+    <a class="restart-button">New Game</a>
     <div class="game-container">
       <div class="game-message">
         <p></p>

--- a/js/grid.js
+++ b/js/grid.js
@@ -1,20 +1,32 @@
-function Grid(size) {
+function Grid(size, previousCellState) {
   this.size = size;
-
-  this.cells = [];
-
-  this.build();
+  this.cells = previousCellState ? this.buildFromPreviousState(previousCellState) : this.buildNew();
 }
 
 // Build a grid of the specified size
-Grid.prototype.build = function () {
+Grid.prototype.buildNew = function () {
+  var cells = [];
   for (var x = 0; x < this.size; x++) {
-    var row = this.cells[x] = [];
+    var row = cells[x] = [];
 
     for (var y = 0; y < this.size; y++) {
       row.push(null);
     }
   }
+  return cells;
+};
+
+Grid.prototype.buildFromPreviousState = function (state) {
+    var cells = [];
+    for (var x = 0; x < this.size; x++) {
+        var row = cells[x] = [];
+
+        for (var y = 0; y < this.size; y++) {
+            var tileState = state[x][y];
+            row.push(tileState ? new Tile(tileState.position, tileState.value) : null);
+        }
+    }
+    return cells;
 };
 
 // Find the first available random position
@@ -81,4 +93,20 @@ Grid.prototype.removeTile = function (tile) {
 Grid.prototype.withinBounds = function (position) {
   return position.x >= 0 && position.x < this.size &&
          position.y >= 0 && position.y < this.size;
+};
+
+Grid.prototype.gridState = function () {
+  var cellState = [];
+  for (var x = 0; x < this.size; x++) {
+    var row = cellState[x] = [];
+
+    for (var y = 0; y < this.size; y++) {
+        row.push(this.cells[x][y] ? this.cells[x][y].tileState() : null);
+    }
+  }
+
+  return {
+      size: this.size,
+      cells: cellState
+  }
 };

--- a/js/keyboard_input_manager.js
+++ b/js/keyboard_input_manager.js
@@ -57,6 +57,10 @@ KeyboardInputManager.prototype.listen = function () {
   retry.addEventListener("click", this.restart.bind(this));
   retry.addEventListener("touchend", this.restart.bind(this));
 
+  var restart = document.querySelector(".restart-button");
+  restart.addEventListener("click", this.restart.bind(this));
+  restart.addEventListener("touchend", this.restart.bind(this));
+
   var keepPlaying = document.querySelector(".keep-playing-button");
   keepPlaying.addEventListener("click", this.keepPlaying.bind(this));
   keepPlaying.addEventListener("touchend", this.keepPlaying.bind(this));

--- a/js/local_score_manager.js
+++ b/js/local_score_manager.js
@@ -19,7 +19,8 @@ window.fakeStorage = {
 };
 
 function LocalScoreManager() {
-  this.key     = "bestScore";
+  this.bestScoreKey     = "bestScore";
+  this.gameStateKey     = "gameState";
 
   var supported = this.localStorageSupported();
   this.storage = supported ? window.localStorage : window.fakeStorage;
@@ -38,11 +39,23 @@ LocalScoreManager.prototype.localStorageSupported = function () {
   }
 };
 
-LocalScoreManager.prototype.get = function () {
-  return this.storage.getItem(this.key) || 0;
+LocalScoreManager.prototype.getBestScore = function () {
+  return this.storage.getItem(this.bestScoreKey) || 0;
 };
 
-LocalScoreManager.prototype.set = function (score) {
-  this.storage.setItem(this.key, score);
+LocalScoreManager.prototype.setBestScore = function (score) {
+  this.storage.setItem(this.bestScoreKey, score);
 };
 
+LocalScoreManager.prototype.getGameState = function () {
+    var stateJSON = this.storage.getItem(this.gameStateKey);
+    return stateJSON ? JSON.parse(stateJSON) : null;
+};
+
+LocalScoreManager.prototype.setGameState = function (gameState) {
+    this.storage.setItem(this.gameStateKey, JSON.stringify(gameState));
+};
+
+LocalScoreManager.prototype.clearGameState = function () {
+    this.storage.removeItem(this.gameStateKey);
+};

--- a/js/tile.js
+++ b/js/tile.js
@@ -15,3 +15,13 @@ Tile.prototype.updatePosition = function (position) {
   this.x = position.x;
   this.y = position.y;
 };
+
+Tile.prototype.tileState = function () {
+    return {
+        position: {
+            x: this.x,
+            y: this.y
+        },
+        value: this.value
+    };
+}

--- a/style/main.css
+++ b/style/main.css
@@ -143,8 +143,21 @@ hr {
   100% {
     opacity: 1; } }
 
+.restart-button {
+  display: inline-block;
+  background: #8f7a66;
+  border-radius: 3px;
+  padding: 0 20px;
+  text-decoration: none;
+  color: #f9f6f2;
+  height: 40px;
+  line-height: 42px;
+  display: block;
+  width: 100px;
+  margin: 10px auto 10px auto;
+  text-align: center; }
+
 .game-container {
-  margin-top: 40px;
   position: relative;
   padding: 15px;
   cursor: default;
@@ -515,7 +528,6 @@ hr {
     margin-bottom: 10px; }
 
   .game-container {
-    margin-top: 40px;
     position: relative;
     padding: 10px;
     cursor: default;

--- a/style/main.scss
+++ b/style/main.scss
@@ -168,10 +168,17 @@ hr {
   line-height: 42px;
 }
 
+.restart-button {
+  @include button;
+  display: block;
+  width: 100px;
+  margin: 10px auto 10px auto;
+  text-align: center;
+}
+
 // Game field mixin used to render CSS at different width
 @mixin game-field {
   .game-container {
-    margin-top: 40px;
     position: relative;
     padding: $grid-spacing;
 


### PR DESCRIPTION
Hi, I've added support for persisting and reloading the game stage.  On each move, the GameManager and Board state are serialized to LocalStorage (just before the Actuator runs).  On load if the game state is present, the GameManager and Board are initialized based on the saved state, otherwise they initialize normally.  Since reloads do not reset the game anymore, I've added a New Game button above the board (the styling and placement, I'm not crazy about).

This, along with the cache manifest PR would make for a 100% offline app.
