### PR TITLE
Stop IE from selecting game container elements. (Fixes Mobile IE trying to highlight numbers on swiping)

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -151,6 +151,7 @@ hr {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -moz-user-select: none;
+  -ms-user-select: none;
   background: #bbada0;
   border-radius: 6px;
   width: 500px;
@@ -523,6 +524,7 @@ hr {
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     -moz-user-select: none;
+    -ms-user-select: none;
     background: #bbada0;
     border-radius: 6px;
     width: 280px;


### PR DESCRIPTION
Added IE specific user select to the game container.
-ms-user-select: none;
