### PR TITLE
Removes the spacebar "feature"

### DIFF
--- a/js/keyboard_input_manager.js
+++ b/js/keyboard_input_manager.js
@@ -60,7 +60,7 @@ KeyboardInputManager.prototype.listen = function () {
         self.emit("move", mapped);
       }
 
-      if (event.which === 32) self.restart.bind(self)(event);
+     
     }
   });
 


### PR DESCRIPTION
If a user wants to start a new game, they should refresh the page.
It is far too easy to accidentally press the spacebar mid game.
