### PR TITLE
Add Gamepad Support

### DIFF
--- a/js/keyboard_input_manager.js
+++ b/js/keyboard_input_manager.js
@@ -111,13 +111,7 @@ KeyboardInputManager.prototype.pollGamepad = function () {
     }
 
     // check gamepad again on next animation frame
-    if (window.requestAnimationFrame) {
-      window.requestAnimationFrame(nextPoll);
-    } else if (window.mozRequestAnimationFrame) {
-      window.mozRequestAnimationFrame(nextPoll);
-    } else if (window.webkitRequestAnimationFrame) {
-      window.webkitRequestAnimationFrame(nextPoll);
-    }
+    window.requestAnimationFrame(nextPoll);
   }
 
 };


### PR DESCRIPTION
I had my xbox 360 controller sitting on my desk and a couple of free hours so I thought - wouldn't it be great to play 2048 with my gamepad?

So far it's only works on Chrome. I got started on Firefox support, and that got boring fast and I've run out of time to waste this afternoon.

D pad & left analog stick work (but are maybe a little sensitive?), and if you're in game over mode, any button you mash will restart.

You can test it out at http://joho.github.io/2048/ I've played a few times and it appears to work fine.
