### PR TITLE
Add status bar style for iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="shortcut icon" href="favicon.ico">
   <link rel="apple-touch-icon" href="meta/apple-touch-icon.png">
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
 
   <meta name="HandheldFriendly" content="True">
   <meta name="MobileOptimized" content="320">


### PR DESCRIPTION
Previously, when added to the home screen, 2048 would show up like this on iOS (notice the statusbar):
![White text against beige background](http://cl.ly/UcAF/old.png)

This PR changes it to this:
![White text against black status bar on top](http://cl.ly/Uc9j/new.png)

(Sorry about the huge images)
