### PR TITLE
Made animframe_polyfill.js JSHint compliant

### DIFF
--- a/js/animframe_polyfill.js
+++ b/js/animframe_polyfill.js
@@ -1,17 +1,19 @@
-(function() {
+(function () {
   var lastTime = 0;
   var vendors = ['webkit', 'moz'];
-  for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
-    window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
-    window.cancelAnimationFrame =
-    window[vendors[x]+'CancelAnimationFrame'] || window[vendors[x]+'CancelRequestAnimationFrame'];
+  for (var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
+    window.requestAnimationFrame = window[vendors[x] + 'RequestAnimationFrame'];
+    window.cancelAnimationFrame = window[vendors[x] + 'CancelAnimationFrame'] ||
+      window[vendors[x] + 'CancelRequestAnimationFrame'];
   }
 
   if (!window.requestAnimationFrame) {
-    window.requestAnimationFrame = function(callback, element) {
+    window.requestAnimationFrame = function (callback) {
       var currTime = new Date().getTime();
       var timeToCall = Math.max(0, 16 - (currTime - lastTime));
-      var id = window.setTimeout(function() { callback(currTime + timeToCall); },
+      var id = window.setTimeout(function () {
+        callback(currTime + timeToCall);
+      },
       timeToCall);
       lastTime = currTime + timeToCall;
       return id;
@@ -19,7 +21,7 @@
   }
 
   if (!window.cancelAnimationFrame) {
-    window.cancelAnimationFrame = function(id) {
+    window.cancelAnimationFrame = function (id) {
       clearTimeout(id);
     };
   }


### PR DESCRIPTION
There's a few more errors, but those would require more in-depth refactors.

JSHint results:

```
> jshint js/*
animframe_polyfill.js: line 1, col 10, Missing space after 'function'.
animframe_polyfill.js: line 4, col 6, Missing space after 'for'.
animframe_polyfill.js: line 5, col 53, Missing space after ']'.
animframe_polyfill.js: line 5, col 54, Missing space after '+'.
animframe_polyfill.js: line 7, col 98, Line is too long.
animframe_polyfill.js: line 7, col 22, Missing space after ']'.
animframe_polyfill.js: line 7, col 23, Missing space after '+'.
animframe_polyfill.js: line 7, col 67, Missing space after ']'.
animframe_polyfill.js: line 7, col 68, Missing space after '+'.
animframe_polyfill.js: line 11, col 44, Missing space after 'function'.
animframe_polyfill.js: line 14, col 81, Line is too long.
animframe_polyfill.js: line 14, col 42, Missing space after 'function'.
animframe_polyfill.js: line 22, col 43, Missing space after 'function'.
animframe_polyfill.js: line 11, col 62, 'element' is defined but never used.

bind_polyfill.js: line 1, col 19, Extending prototype of native object: 'Function'.

game_manager.js: line 263, col 52, Blocks are nested too deeply. (5)

16 errors
```
