### PR TITLE
Add !global on mobile variable redefinitions

### DIFF
--- a/style/main.scss
+++ b/style/main.scss
@@ -474,12 +474,12 @@ hr {
 
 @include smaller($mobile-threshold) {
   // Redefine variables for smaller screens
-  $field-width: 280px;
-  $grid-spacing: 10px;
-  $grid-row-cells: 4;
-  $tile-size: ($field-width - $grid-spacing * ($grid-row-cells + 1)) / $grid-row-cells;
-  $tile-border-radius: 3px;
-  $game-container-margin-top: 17px;
+  $field-width: 280px !global;
+  $grid-spacing: 10px !global;
+  $grid-row-cells: 4 !global;
+  $tile-size: ($field-width - $grid-spacing * ($grid-row-cells + 1)) / $grid-row-cells !global;
+  $tile-border-radius: 3px !global;
+  $game-container-margin-top: 17px !global;
 
   html, body {
     font-size: 15px;


### PR DESCRIPTION
Sass 3.3.0+ issues a few warnings like this:

   DEPRECATION WARNING on line 477 of style/main.scss:
   Assigning to global variable "$field-width" by default is deprecated.
   In future versions of Sass, this will create a new local variable.
   If you want to assign to the global variable, use "$field-width: 280px !global" instead.
   Note that this will be incompatible with Sass 3.2.

Adding !global as suggested works fine, with no warnings, and doesn't
change the resulting main.css at all.
