### PR TITLE
fix the issue   https://github.com/gabrielecirulli/2048/issues/180

### DIFF
--- a/js/game_manager.js
+++ b/js/game_manager.js
@@ -24,6 +24,8 @@ GameManager.prototype.restart = function () {
 GameManager.prototype.keepPlaying = function () {
   this.keepPlaying = true;
   this.actuator.continueGame(); // Clear the game won/lost message
+  this.actuate();// add this line to fix https://github.com/gabrielecirulli/2048/issues/180
+
 };
 
 // Return true if the game is lost, or has won and the user hasn't kept playing
@@ -93,7 +95,8 @@ GameManager.prototype.actuate = function () {
     over:       this.over,
     won:        this.won,
     bestScore:  this.storageManager.getBestScore(),
-    terminated: this.isGameTerminated()
+    terminated: this.isGameTerminated(),
+    keepPlaying: this.keepPlaying // add to fix https://github.com/gabrielecirulli/2048/issues/180
   });
 
 };

--- a/js/html_actuator.js
+++ b/js/html_actuator.js
@@ -25,6 +25,9 @@ HTMLActuator.prototype.actuate = function (grid, metadata) {
     self.updateBestScore(metadata.bestScore);
 
     if (metadata.terminated) {
+        // when last move get a 2048 tile and couldn't find next move,
+        // metadata.over and metadata.won are both set to true
+        //
       if (metadata.over) {
         self.message(false); // You lose
       } else if (metadata.won) {

--- a/js/html_actuator.js
+++ b/js/html_actuator.js
@@ -25,10 +25,17 @@ HTMLActuator.prototype.actuate = function (grid, metadata) {
     self.updateBestScore(metadata.bestScore);
 
     if (metadata.terminated) {
-        // when last move get a 2048 tile and couldn't find next move,
+        // https://github.com/gabrielecirulli/2048/issues/180
+        // when last move create a 2048 tile and couldn't find next move,
         // metadata.over and metadata.won are both set to true
-        //
+
       if (metadata.over) {
+        //edge case ;
+        if (metadata.won && !metadata.keepPlaying){
+        // last move won , and no more move ;
+          self.message(true);
+          return;
+        }
         self.message(false); // You lose
       } else if (metadata.won) {
         self.message(true); // You win!


### PR DESCRIPTION
fix the issue 
https://github.com/gabrielecirulli/2048/issues/180

1 .  to reproduce the bug 

![image](https://cloud.githubusercontent.com/assets/7328508/2838024/f92da672-d028-11e3-83ce-19dcbd24636e.png)
after we move up

![image](https://cloud.githubusercontent.com/assets/7328508/2838050/6df6279a-d029-11e3-847e-706488007c7e.png)

the game display game over ,instead of the "you win" message.


the fix 

outline : 
1. add an actuate call in GameManager's keepPlaying method.
2. pass keepPlaying to actuator.
3. add logic for last move won. 

see code for detail 
