### PR TITLE
No more ugly color when a button was clicked

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -104,7 +104,8 @@ a {
   color: #776e65;
   font-weight: bold;
   text-decoration: underline;
-  cursor: pointer; }
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent; }
 
 strong.important {
   text-transform: uppercase; }

--- a/style/main.scss
+++ b/style/main.scss
@@ -125,6 +125,7 @@ a {
   font-weight: bold;
   text-decoration: underline;
   cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
 }
 
 strong {


### PR DESCRIPTION
This fix remove the ugly blue background color when a button was clicked with a smartphone or tablet. It works only for browser based on webkit.
