### PR TITLE
Optimization for tileMatchesAvailable

### DIFF
--- a/js/game_manager.js
+++ b/js/game_manager.js
@@ -250,7 +250,7 @@ GameManager.prototype.tileMatchesAvailable = function () {
       tile = this.grid.cellContent({ x: x, y: y });
 
       if (tile) {
-        for (var direction = 0; direction < 4; direction++) {
+        for (var direction = 0; direction < 2; direction++) {
           var vector = self.getVector(direction);
           var cell   = { x: x + vector.x, y: y + vector.y };
 


### PR DESCRIPTION
A small change to tileMatchesAvailable.  There is no need to check every
tile on all 4 sides, which will check every pair of tiles twice.  It is
sufficient to check on two sides.
