### PR TITLE
on Galaxy SII and S, to alleviate flickering issues while moving tiles b...

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -231,7 +231,10 @@ hr {
 .tile, .tile .tile-inner {
   width: 107px;
   height: 107px;
-  line-height: 116.25px; }
+  line-height: 116.25px;
+  -webkit-transform: translateZ(0);
+  -moz-transform: translateZ(0);
+  transform: translateZ(0); }
 .tile.tile-position-1-1 {
   -webkit-transform: translate(0px, 0px);
   -moz-transform: translate(0px, 0px);
@@ -633,7 +636,10 @@ hr {
   .tile, .tile .tile-inner {
     width: 58px;
     height: 58px;
-    line-height: 67.5px; }
+    line-height: 67.5px;
+    -webkit-transform: translateZ(0);
+    -moz-transform: translateZ(0);
+    transform: translateZ(0); }
   .tile.tile-position-1-1 {
     -webkit-transform: translate(0px, 0px);
     -moz-transform: translate(0px, 0px);

--- a/style/main.scss
+++ b/style/main.scss
@@ -293,6 +293,7 @@ hr {
       width: ceil($tile-size);
       height: ceil($tile-size);
       line-height: $tile-size + 10px;
+      @include transform(translateZ(0));
     }
 
     // Build position classes


### PR DESCRIPTION
In the Webviews of Galaxy S III and Galaxy S, while moving tiles, the tiles are flickering severely on the devices.
The root cause is that right before moving tiles, animation CSS is applied which creates a set of corresponding GPU textures for the tiles. after animations end, the CSS are removed, which subsequently remove GPU textures for them. in the above mentioned devices. switching between CPU memory and GPU textures cause flickering. In order to alleviate this issue, the best way I know of is to keep tiles in GPU textures all the time.
It can be achieved by the single line of CSS as per my patch
