### PR TITLE
Fix .scss files to work with Sass 3.4.5.

### DIFF
--- a/style/helpers.scss
+++ b/style/helpers.scss
@@ -53,13 +53,13 @@
 
 // Keyframe animations
 @mixin keyframes($animation-name) {
-  @-webkit-keyframes $animation-name {
+  @-webkit-keyframes #{$animation-name} {
     @content;
   }
-  @-moz-keyframes $animation-name {
+  @-moz-keyframes #{$animation-name} {
     @content;
   }
-  @keyframes $animation-name {
+  @keyframes #{$animation-name} {
     @content;
   }
 }

--- a/style/main.css
+++ b/style/main.css
@@ -26,7 +26,6 @@ h1.title {
   0% {
     top: 25px;
     opacity: 1; }
-
   100% {
     top: -50px;
     opacity: 0; } }
@@ -34,7 +33,6 @@ h1.title {
   0% {
     top: 25px;
     opacity: 1; }
-
   100% {
     top: -50px;
     opacity: 0; } }
@@ -42,7 +40,6 @@ h1.title {
   0% {
     top: 25px;
     opacity: 1; }
-
   100% {
     top: -50px;
     opacity: 0; } }
@@ -122,19 +119,16 @@ hr {
 @-webkit-keyframes fade-in {
   0% {
     opacity: 0; }
-
   100% {
     opacity: 1; } }
 @-moz-keyframes fade-in {
   0% {
     opacity: 0; }
-
   100% {
     opacity: 1; } }
 @keyframes fade-in {
   0% {
     opacity: 0; }
-
   100% {
     opacity: 1; } }
 .game-container {
@@ -384,7 +378,6 @@ hr {
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     transform: scale(0); }
-
   100% {
     opacity: 1;
     -webkit-transform: scale(1);
@@ -396,7 +389,6 @@ hr {
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     transform: scale(0); }
-
   100% {
     opacity: 1;
     -webkit-transform: scale(1);
@@ -408,7 +400,6 @@ hr {
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     transform: scale(0); }
-
   100% {
     opacity: 1;
     -webkit-transform: scale(1);
@@ -427,12 +418,10 @@ hr {
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     transform: scale(0); }
-
   50% {
     -webkit-transform: scale(1.2);
     -moz-transform: scale(1.2);
     transform: scale(1.2); }
-
   100% {
     -webkit-transform: scale(1);
     -moz-transform: scale(1);
@@ -442,12 +431,10 @@ hr {
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     transform: scale(0); }
-
   50% {
     -webkit-transform: scale(1.2);
     -moz-transform: scale(1.2);
     transform: scale(1.2); }
-
   100% {
     -webkit-transform: scale(1);
     -moz-transform: scale(1);
@@ -457,12 +444,10 @@ hr {
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     transform: scale(0); }
-
   50% {
     -webkit-transform: scale(1.2);
     -moz-transform: scale(1.2);
     transform: scale(1.2); }
-
   100% {
     -webkit-transform: scale(1);
     -moz-transform: scale(1);

--- a/style/main.scss
+++ b/style/main.scss
@@ -9,7 +9,7 @@ $tile-border-radius: 3px;
 
 $mobile-threshold: $field-width + 20px;
 
-$text-color: #776E65;
+$text-color: #776e65;
 $bright-text-color: #f9f6f2;
 
 $tile-color: #eee4da;
@@ -474,12 +474,12 @@ hr {
 
 @include smaller($mobile-threshold) {
   // Redefine variables for smaller screens
-  $field-width: 280px;
-  $grid-spacing: 10px;
-  $grid-row-cells: 4;
-  $tile-size: ($field-width - $grid-spacing * ($grid-row-cells + 1)) / $grid-row-cells;
-  $tile-border-radius: 3px;
-  $game-container-margin-top: 17px;
+  $field-width: 280px !global;
+  $grid-spacing: 10px !global;
+  $grid-row-cells: 4 !global;
+  $tile-size: ($field-width - $grid-spacing * ($grid-row-cells + 1)) / $grid-row-cells !global;
+  $tile-border-radius: 3px !global;
+  $game-container-margin-top: 17px !global;
 
   html, body {
     font-size: 15px;


### PR DESCRIPTION
Two bugs here, relative to Sass 3.4.5 (Selective Steve).
The first bug, reported at
https://github.com/dsociative/2048/commit/80258ad81716fd0dc263a3b0e154c7624afe1a0e
is that Sass apparently requires interpolation braces #{} around
a mixin parameter used on the left side of a colon.

The second bug, visible at that same commit, is that when you
refer to an unbound variable inside a mixin, Sass apparently
now looks them up in the global scope rather than in the local
scope of the "caller" of the mixin. For example,

```
@mixin foo() { bar: $bar; }

$bar: 1;
a {
  $bar: 2;
  @include foo();
  baz: $bar;
}
```

gives `a { bar: 1; baz: 2; }`.

This may in fact be a bug in Sass 3.4.5. Upstreamed as
https://github.com/sass/sass/issues/1474
