### PR TITLE
Factor out the rules for merging tiles.

### DIFF
--- a/js/game_manager.js
+++ b/js/game_manager.js
@@ -126,6 +126,11 @@ GameManager.prototype.moveTile = function (tile, cell) {
   tile.updatePosition(cell);
 };
 
+GameManager.prototype.resultOfMerging = function (from, to) {
+  if (from.value !== to.value) return null;
+  return new Tile(null, from.value * 2);
+};
+
 // Move tiles on the grid in the specified direction
 GameManager.prototype.move = function (direction) {
   // 0: up, 1: right, 2: down, 3: left
@@ -152,9 +157,13 @@ GameManager.prototype.move = function (direction) {
         var positions = self.findFarthestPosition(cell, vector);
         var next      = self.grid.cellContent(positions.next);
 
-        // Only one merger per row traversal?
-        if (next && next.value === tile.value && !next.mergedFrom) {
-          var merged = new Tile(positions.next, tile.value * 2);
+        var merged =
+          !next ? null :
+          next.mergedFrom ? null : // Only one merger per row traversal
+          self.resultOfMerging(tile, next);
+
+        if (merged) {
+          merged.updatePosition(positions.next);
           merged.mergedFrom = [tile, next];
 
           self.grid.insertTile(merged);
@@ -256,7 +265,7 @@ GameManager.prototype.tileMatchesAvailable = function () {
 
           var other  = self.grid.cellContent(cell);
 
-          if (other && other.value === tile.value) {
+          if (other && self.resultOfMerging(tile, other)) {
             return true; // These two tiles can be merged
           }
         }

--- a/js/tile.js
+++ b/js/tile.js
@@ -1,7 +1,8 @@
+
 function Tile(position, value) {
-  this.x                = position.x;
-  this.y                = position.y;
-  this.value            = value || 2;
+  this.x                = position ? position.x : null;
+  this.y                = position ? position.y : null;
+  this.value            = value;
 
   this.previousPosition = null;
   this.mergedFrom       = null; // Tracks tiles that merged together


### PR DESCRIPTION
The old code hard-coded the rule "a.value === b.value" in two places,
and also hard-coded the merged tile's value as "a.value * 2".  To make
it easier to hack together variant versions, I've factored this logic
out into a single function GameManager.resultOfMerging(from, to).
If the tiles can't be merged, the function returns null.
If they can, the function returns an appropriately initialized new Tile
(except that the position may safely be left as "null").

No intended functional change.