### PR TITLE
Rotate or flip board (without otherwise affecting gameplay)

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,10 @@
     </p>
     <hr>
     <p>
+      You can use <strong>Q</strong> and <strong>E</strong> to rotate the board left or right. <strong>Z</strong> and <strong>X</strong> will flip it horizontally or vertically. This will not affect the game in any other way.
+    </p>
+    <hr>
+    <p>
     <strong class="important">Note:</strong> This site is the official version of 2048. You can play it on your phone via <a href="http://git.io/2048">http://git.io/2048.</a> All other apps or sites are derivatives or fakes, and should be used with caution.
     </p>
     <hr>

--- a/js/game_manager.js
+++ b/js/game_manager.js
@@ -7,6 +7,9 @@ function GameManager(size, InputManager, Actuator, StorageManager) {
   this.startTiles     = 2;
 
   this.inputManager.on("move", this.move.bind(this));
+  this.inputManager.on("rotate", this.rotate.bind(this));
+  this.inputManager.on("flipX", this.flipX.bind(this));
+  this.inputManager.on("flipY", this.flipY.bind(this));
   this.inputManager.on("restart", this.restart.bind(this));
   this.inputManager.on("keepPlaying", this.keepPlaying.bind(this));
 
@@ -269,4 +272,25 @@ GameManager.prototype.tileMatchesAvailable = function () {
 
 GameManager.prototype.positionsEqual = function (first, second) {
   return first.x === second.x && first.y === second.y;
+};
+
+GameManager.prototype.rotate = function (n) {
+  if (this.over) { return; }
+  this.prepareTiles();
+  this.grid.rotate(n);
+  this.actuate();
+};
+
+GameManager.prototype.flipX = function () {
+  if (this.over) { return; }
+  this.prepareTiles();
+  this.grid.flipX();
+  this.actuate();
+};
+
+GameManager.prototype.flipY = function () {
+  if (this.over) { return; }
+  this.prepareTiles();
+  this.grid.flipY();
+  this.actuate();
 };

--- a/js/grid.js
+++ b/js/grid.js
@@ -115,3 +115,39 @@ Grid.prototype.serialize = function () {
     cells: cellState
   };
 };
+
+Grid.prototype.transpose = function () {
+  var newCells = this.empty();
+  for (x = 0; x < this.size; x++) {
+    for (y = 0; y < this.size; y++) {
+      var cell = this.cells[x][y];
+      newCells[y][x] = cell;
+    }
+  }
+  this.cells = newCells;
+};
+
+Grid.prototype.flipX = function (hold) {
+  this.cells = this.cells.reverse();
+  hold || this.updateTiles();
+};
+
+Grid.prototype.flipY = function (hold) {
+  this.cells = this.cells.map(function (row) { return row.reverse(); });
+  hold || this.updateTiles();
+};
+
+// Rotate by (n * 90 degrees) clockwise
+Grid.prototype.rotate = function (n) {
+  switch ((n % 4 + 4) % 4) {
+    case 1: this.transpose(); this.flipX(); break;
+    case 2: this.flipX(true); this.flipY(); break;
+    case 3: this.transpose(); this.flipY(); break;
+  }
+};
+
+Grid.prototype.updateTiles = function () {
+  this.eachCell(function (x, y, tile) {
+    tile && tile.updatePosition({ x: x, y: y });
+  });
+};

--- a/js/keyboard_input_manager.js
+++ b/js/keyboard_input_manager.js
@@ -46,7 +46,12 @@ KeyboardInputManager.prototype.listen = function () {
     87: 0, // W
     68: 1, // D
     83: 2, // S
-    65: 3  // A
+    65: 3, // A
+    
+    81: 10, // Q
+    69: 11, // E
+    90: 12, // Z
+    88: 13, // X
   };
 
   // Respond to direction keys
@@ -55,10 +60,14 @@ KeyboardInputManager.prototype.listen = function () {
                     event.shiftKey;
     var mapped    = map[event.which];
 
-    if (!modifiers) {
-      if (mapped !== undefined) {
-        event.preventDefault();
-        self.emit("move", mapped);
+    if (!modifiers && mapped !== undefined) {
+      event.preventDefault();
+      switch (mapped) {
+        case 10: self.emit("rotate", -1); break;
+        case 11: self.emit("rotate", 1); break;
+        case 12: self.emit("flipX"); break;
+        case 13: self.emit("flipY"); break;
+        default: self.emit("move", mapped); break;
       }
     }
 


### PR DESCRIPTION
I find myself favoring the bottom-right corner for 'stashing' large tiles. When this goes bad and I move them away, either accidentally or because I have no other moves, the game might be recoverable, but only if I move them to another corner. This _should_ be an equivalent situation, but I find that it's a lot easier to make mistakes and moves require more thought.

So I added a few keys to rotate (Q, E) or flip (Z, X) the board.
