### PR TITLE
fixes type error surrounding `event.targetTouches`

### DIFF
--- a/js/keyboard_input_manager.js
+++ b/js/keyboard_input_manager.js
@@ -79,7 +79,7 @@ KeyboardInputManager.prototype.listen = function () {
 
   gameContainer.addEventListener(this.eventTouchstart, function (event) {
     if ((!window.navigator.msPointerEnabled && event.touches.length > 1) ||
-        event.targetTouches > 1) {
+        event.targetTouches.length > 1) {
       return; // Ignore if touching with more than 1 finger
     }
 
@@ -100,7 +100,7 @@ KeyboardInputManager.prototype.listen = function () {
 
   gameContainer.addEventListener(this.eventTouchend, function (event) {
     if ((!window.navigator.msPointerEnabled && event.touches.length > 0) ||
-        event.targetTouches > 0) {
+        event.targetTouches.length > 0) {
       return; // Ignore if still touching with one or more fingers
     }
 


### PR DESCRIPTION
[While porting this code to typescript for a presentation](https://github.com/Gitgiddy/2048/tree/ported_to_typescript) the compiler seems to have caught a type error on these two lines.  It seems to me that `.length` was intended but omitted.  This fixes the supposed bug in the original javascript.

`event.targetTouches` returns, [by documentation](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/targetTouches), a [TouchList](https://developer.mozilla.org/en-US/docs/Web/API/TouchList) which would not be comparable to a number.