### PR TITLE
DRYed up main.scss and fixed tile sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .sass-cache/
+*.css.map

--- a/index.html
+++ b/index.html
@@ -40,36 +40,9 @@
         </div>
       </div>
 
-      <div class="grid-container">
-        <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-        </div>
-        <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-        </div>
-        <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-        </div>
-        <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-        </div>
-      </div>
+      <div class="grid-container"></div>
 
-      <div class="tile-container">
-
-      </div>
+      <div class="tile-container"></div>
     </div>
 
     <p class="game-explanation">

--- a/js/game_manager.js
+++ b/js/game_manager.js
@@ -10,7 +10,23 @@ function GameManager(size, InputManager, Actuator, StorageManager) {
   this.inputManager.on("restart", this.restart.bind(this));
   this.inputManager.on("keepPlaying", this.keepPlaying.bind(this));
 
+  this.displayCells();
   this.setup();
+}
+
+GameManager.prototype.displayCells = function() {
+  var gridContainer = document.querySelector(".grid-container");
+  for (var x = 0; x < this.size; x++) {
+    var row = document.createElement("div");
+    row.className = "grid-row";
+
+    for (var y = 0; y < this.size; y++) {
+      var cell = document.createElement("div");
+      cell.className = "grid-cell";
+      row.appendChild(cell);
+    }
+    gridContainer.appendChild(row);
+  }
 }
 
 // Restart the game

--- a/style/helpers.scss
+++ b/style/helpers.scss
@@ -8,8 +8,8 @@
   @if $exponent > 1 {
     @for $i from 2 through $exponent {
       $value: $value * $base; } }
-  // negitive intergers get divided. A number divided by itself is 1
-  @if $exponent < 1 {
+  // negative intergers get divided. A number divided by itself is 1
+  @else if $exponent < 1 {
     @for $i from 0 through -$exponent {
       $value: $value / $base; } }
   // return the last value written
@@ -50,6 +50,12 @@
   -moz-transform: $args;
   -ms-transform: $args;
   transform: $args;
+}
+
+@mixin boxsize($args...) {
+    -webkit-box-sizing: $args;
+    -moz-box-sizing: $args;
+    box-sizing: $args;
 }
 
 // Keyframe animations

--- a/style/main.css
+++ b/style/main.css
@@ -3,17 +3,27 @@ html, body {
   margin: 0;
   padding: 0;
   background: #faf8ef;
-  color: #776e65;
+  color: #776E65;
   font-family: "Clear Sans", "Helvetica Neue", Arial, sans-serif;
   font-size: 18px; }
+  @media screen and (max-width: 520px) {
+    html, body {
+      font-size: 15px; } }
 
 body {
   margin: 80px 0; }
+  @media screen and (max-width: 520px) {
+    body {
+      margin: 20px 0;
+      padding: 0 20px; } }
 
 .heading:after {
   content: "";
   display: block;
   clear: both; }
+@media screen and (max-width: 520px) {
+  .heading {
+    margin-bottom: 10px; } }
 
 h1.title {
   font-size: 80px;
@@ -21,28 +31,29 @@ h1.title {
   margin: 0;
   display: block;
   float: left; }
+  @media screen and (max-width: 520px) {
+    h1.title {
+      font-size: 27px;
+      margin-top: 15px; } }
 
-@-webkit-keyframes move-up {
+@-webkit-keyframes $animation-name {
   0% {
     top: 25px;
     opacity: 1; }
-
   100% {
     top: -50px;
     opacity: 0; } }
-@-moz-keyframes move-up {
+@-moz-keyframes $animation-name {
   0% {
     top: 25px;
     opacity: 1; }
-
   100% {
     top: -50px;
     opacity: 0; } }
-@keyframes move-up {
+@keyframes $animation-name {
   0% {
     top: 25px;
     opacity: 1; }
-
   100% {
     top: -50px;
     opacity: 0; } }
@@ -63,6 +74,11 @@ h1.title {
   color: white;
   margin-top: 8px;
   text-align: center; }
+  @media screen and (max-width: 520px) {
+    .score-container, .best-container {
+      margin-top: 0;
+      padding: 15px 10px;
+      min-width: 40px; } }
   .score-container:after, .best-container:after {
     position: absolute;
     width: 100%;
@@ -101,7 +117,7 @@ p {
   line-height: 1.65; }
 
 a {
-  color: #776e65;
+  color: #776E65;
   font-weight: bold;
   text-decoration: underline;
   cursor: pointer; }
@@ -118,23 +134,23 @@ hr {
 .container {
   width: 500px;
   margin: 0 auto; }
+  @media screen and (max-width: 520px) {
+    .container {
+      width: 280px; } }
 
-@-webkit-keyframes fade-in {
+@-webkit-keyframes $animation-name {
   0% {
     opacity: 0; }
-
   100% {
     opacity: 1; } }
-@-moz-keyframes fade-in {
+@-moz-keyframes $animation-name {
   0% {
     opacity: 0; }
-
   100% {
     opacity: 1; } }
-@keyframes fade-in {
+@keyframes $animation-name {
   0% {
     opacity: 0; }
-
   100% {
     opacity: 1; } }
 .game-container {
@@ -156,6 +172,12 @@ hr {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box; }
+  @media screen and (max-width: 520px) {
+    .game-container {
+      margin-top: 17px;
+      padding: 10px;
+      width: 280px;
+      height: 280px; } }
   .game-container .game-message {
     display: none;
     position: absolute;
@@ -178,9 +200,18 @@ hr {
       height: 60px;
       line-height: 60px;
       margin-top: 222px; }
+      @media screen and (max-width: 520px) {
+        .game-container .game-message p {
+          font-size: 30px !important;
+          height: 30px !important;
+          line-height: 30px !important;
+          margin-top: 90px !important; } }
     .game-container .game-message .lower {
       display: block;
       margin-top: 59px; }
+      @media screen and (max-width: 520px) {
+        .game-container .game-message .lower {
+          margin-top: 30px !important; } }
     .game-container .game-message a {
       display: inline-block;
       background: #8f7a66;
@@ -207,6 +238,9 @@ hr {
 
 .grid-row {
   margin-bottom: 15px; }
+  @media screen and (max-width: 520px) {
+    .grid-row {
+      margin-bottom: 10px; } }
   .grid-row:last-child {
     margin-bottom: 0; }
   .grid-row:after {
@@ -221,6 +255,11 @@ hr {
   float: left;
   border-radius: 3px;
   background: rgba(238, 228, 218, 0.35); }
+  @media screen and (max-width: 520px) {
+    .grid-cell {
+      width: 57.5px;
+      height: 57.5px;
+      margin-right: 10px; } }
   .grid-cell:last-child {
     margin-right: 0; }
 
@@ -232,86 +271,187 @@ hr {
   width: 107px;
   height: 107px;
   line-height: 107px; }
+  @media screen and (max-width: 520px) {
+    .tile, .tile .tile-inner {
+      width: 58px;
+      height: 58px;
+      line-height: 58px; } }
 .tile.tile-position-1-1 {
   -webkit-transform: translate(0px, 0px);
   -moz-transform: translate(0px, 0px);
   -ms-transform: translate(0px, 0px);
   transform: translate(0px, 0px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-1-1 {
+      -webkit-transform: translate(0px, 0px);
+      -moz-transform: translate(0px, 0px);
+      -ms-transform: translate(0px, 0px);
+      transform: translate(0px, 0px); } }
 .tile.tile-position-1-2 {
   -webkit-transform: translate(0px, 121px);
   -moz-transform: translate(0px, 121px);
   -ms-transform: translate(0px, 121px);
   transform: translate(0px, 121px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-1-2 {
+      -webkit-transform: translate(0px, 67px);
+      -moz-transform: translate(0px, 67px);
+      -ms-transform: translate(0px, 67px);
+      transform: translate(0px, 67px); } }
 .tile.tile-position-1-3 {
   -webkit-transform: translate(0px, 242px);
   -moz-transform: translate(0px, 242px);
   -ms-transform: translate(0px, 242px);
   transform: translate(0px, 242px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-1-3 {
+      -webkit-transform: translate(0px, 135px);
+      -moz-transform: translate(0px, 135px);
+      -ms-transform: translate(0px, 135px);
+      transform: translate(0px, 135px); } }
 .tile.tile-position-1-4 {
   -webkit-transform: translate(0px, 363px);
   -moz-transform: translate(0px, 363px);
   -ms-transform: translate(0px, 363px);
   transform: translate(0px, 363px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-1-4 {
+      -webkit-transform: translate(0px, 202px);
+      -moz-transform: translate(0px, 202px);
+      -ms-transform: translate(0px, 202px);
+      transform: translate(0px, 202px); } }
 .tile.tile-position-2-1 {
   -webkit-transform: translate(121px, 0px);
   -moz-transform: translate(121px, 0px);
   -ms-transform: translate(121px, 0px);
   transform: translate(121px, 0px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-2-1 {
+      -webkit-transform: translate(67px, 0px);
+      -moz-transform: translate(67px, 0px);
+      -ms-transform: translate(67px, 0px);
+      transform: translate(67px, 0px); } }
 .tile.tile-position-2-2 {
   -webkit-transform: translate(121px, 121px);
   -moz-transform: translate(121px, 121px);
   -ms-transform: translate(121px, 121px);
   transform: translate(121px, 121px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-2-2 {
+      -webkit-transform: translate(67px, 67px);
+      -moz-transform: translate(67px, 67px);
+      -ms-transform: translate(67px, 67px);
+      transform: translate(67px, 67px); } }
 .tile.tile-position-2-3 {
   -webkit-transform: translate(121px, 242px);
   -moz-transform: translate(121px, 242px);
   -ms-transform: translate(121px, 242px);
   transform: translate(121px, 242px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-2-3 {
+      -webkit-transform: translate(67px, 135px);
+      -moz-transform: translate(67px, 135px);
+      -ms-transform: translate(67px, 135px);
+      transform: translate(67px, 135px); } }
 .tile.tile-position-2-4 {
   -webkit-transform: translate(121px, 363px);
   -moz-transform: translate(121px, 363px);
   -ms-transform: translate(121px, 363px);
   transform: translate(121px, 363px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-2-4 {
+      -webkit-transform: translate(67px, 202px);
+      -moz-transform: translate(67px, 202px);
+      -ms-transform: translate(67px, 202px);
+      transform: translate(67px, 202px); } }
 .tile.tile-position-3-1 {
   -webkit-transform: translate(242px, 0px);
   -moz-transform: translate(242px, 0px);
   -ms-transform: translate(242px, 0px);
   transform: translate(242px, 0px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-3-1 {
+      -webkit-transform: translate(135px, 0px);
+      -moz-transform: translate(135px, 0px);
+      -ms-transform: translate(135px, 0px);
+      transform: translate(135px, 0px); } }
 .tile.tile-position-3-2 {
   -webkit-transform: translate(242px, 121px);
   -moz-transform: translate(242px, 121px);
   -ms-transform: translate(242px, 121px);
   transform: translate(242px, 121px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-3-2 {
+      -webkit-transform: translate(135px, 67px);
+      -moz-transform: translate(135px, 67px);
+      -ms-transform: translate(135px, 67px);
+      transform: translate(135px, 67px); } }
 .tile.tile-position-3-3 {
   -webkit-transform: translate(242px, 242px);
   -moz-transform: translate(242px, 242px);
   -ms-transform: translate(242px, 242px);
   transform: translate(242px, 242px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-3-3 {
+      -webkit-transform: translate(135px, 135px);
+      -moz-transform: translate(135px, 135px);
+      -ms-transform: translate(135px, 135px);
+      transform: translate(135px, 135px); } }
 .tile.tile-position-3-4 {
   -webkit-transform: translate(242px, 363px);
   -moz-transform: translate(242px, 363px);
   -ms-transform: translate(242px, 363px);
   transform: translate(242px, 363px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-3-4 {
+      -webkit-transform: translate(135px, 202px);
+      -moz-transform: translate(135px, 202px);
+      -ms-transform: translate(135px, 202px);
+      transform: translate(135px, 202px); } }
 .tile.tile-position-4-1 {
   -webkit-transform: translate(363px, 0px);
   -moz-transform: translate(363px, 0px);
   -ms-transform: translate(363px, 0px);
   transform: translate(363px, 0px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-4-1 {
+      -webkit-transform: translate(202px, 0px);
+      -moz-transform: translate(202px, 0px);
+      -ms-transform: translate(202px, 0px);
+      transform: translate(202px, 0px); } }
 .tile.tile-position-4-2 {
   -webkit-transform: translate(363px, 121px);
   -moz-transform: translate(363px, 121px);
   -ms-transform: translate(363px, 121px);
   transform: translate(363px, 121px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-4-2 {
+      -webkit-transform: translate(202px, 67px);
+      -moz-transform: translate(202px, 67px);
+      -ms-transform: translate(202px, 67px);
+      transform: translate(202px, 67px); } }
 .tile.tile-position-4-3 {
   -webkit-transform: translate(363px, 242px);
   -moz-transform: translate(363px, 242px);
   -ms-transform: translate(363px, 242px);
   transform: translate(363px, 242px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-4-3 {
+      -webkit-transform: translate(202px, 135px);
+      -moz-transform: translate(202px, 135px);
+      -ms-transform: translate(202px, 135px);
+      transform: translate(202px, 135px); } }
 .tile.tile-position-4-4 {
   -webkit-transform: translate(363px, 363px);
   -moz-transform: translate(363px, 363px);
   -ms-transform: translate(363px, 363px);
   transform: translate(363px, 363px); }
+  @media screen and (max-width: 520px) {
+    .tile.tile-position-4-4 {
+      -webkit-transform: translate(202px, 202px);
+      -moz-transform: translate(202px, 202px);
+      -ms-transform: translate(202px, 202px);
+      transform: translate(202px, 202px); } }
 
 .tile {
   position: absolute;
@@ -328,27 +468,30 @@ hr {
     font-weight: bold;
     z-index: 10;
     font-size: 55px; }
+    @media screen and (max-width: 520px) {
+      .tile .tile-inner {
+        font-size: 35px; } }
   .tile.tile-2 .tile-inner {
     background: #eee4da;
     box-shadow: 0 0 30px 10px rgba(243, 215, 116, 0), inset 0 0 0 1px rgba(255, 255, 255, 0); }
   .tile.tile-4 .tile-inner {
-    background: #ede0c8;
+    background: #eee1c9;
     box-shadow: 0 0 30px 10px rgba(243, 215, 116, 0), inset 0 0 0 1px rgba(255, 255, 255, 0); }
   .tile.tile-8 .tile-inner {
     color: #f9f6f2;
-    background: #f2b179; }
+    background: #f3b27a; }
   .tile.tile-16 .tile-inner {
     color: #f9f6f2;
-    background: #f59563; }
+    background: #f69664; }
   .tile.tile-32 .tile-inner {
     color: #f9f6f2;
-    background: #f67c5f; }
+    background: #f77c5f; }
   .tile.tile-64 .tile-inner {
     color: #f9f6f2;
-    background: #f65e3b; }
+    background: #f75f3b; }
   .tile.tile-128 .tile-inner {
     color: #f9f6f2;
-    background: #edcf72;
+    background: #edd073;
     box-shadow: 0 0 30px 10px rgba(243, 215, 116, 0.2381), inset 0 0 0 1px rgba(255, 255, 255, 0.14286);
     font-size: 45px; }
     @media screen and (max-width: 520px) {
@@ -356,7 +499,7 @@ hr {
         font-size: 25px; } }
   .tile.tile-256 .tile-inner {
     color: #f9f6f2;
-    background: #edcc61;
+    background: #edcc62;
     box-shadow: 0 0 30px 10px rgba(243, 215, 116, 0.31746), inset 0 0 0 1px rgba(255, 255, 255, 0.19048);
     font-size: 45px; }
     @media screen and (max-width: 520px) {
@@ -364,7 +507,7 @@ hr {
         font-size: 25px; } }
   .tile.tile-512 .tile-inner {
     color: #f9f6f2;
-    background: #edc850;
+    background: #edc950;
     box-shadow: 0 0 30px 10px rgba(243, 215, 116, 0.39683), inset 0 0 0 1px rgba(255, 255, 255, 0.2381);
     font-size: 45px; }
     @media screen and (max-width: 520px) {
@@ -388,48 +531,45 @@ hr {
         font-size: 15px; } }
   .tile.tile-super .tile-inner {
     color: #f9f6f2;
-    background: #3c3a32;
+    background: #3c3a33;
     font-size: 30px; }
     @media screen and (max-width: 520px) {
       .tile.tile-super .tile-inner {
         font-size: 10px; } }
 
-@-webkit-keyframes appear {
+@-webkit-keyframes $animation-name {
   0% {
     opacity: 0;
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     -ms-transform: scale(0);
     transform: scale(0); }
-
   100% {
     opacity: 1;
     -webkit-transform: scale(1);
     -moz-transform: scale(1);
     -ms-transform: scale(1);
     transform: scale(1); } }
-@-moz-keyframes appear {
+@-moz-keyframes $animation-name {
   0% {
     opacity: 0;
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     -ms-transform: scale(0);
     transform: scale(0); }
-
   100% {
     opacity: 1;
     -webkit-transform: scale(1);
     -moz-transform: scale(1);
     -ms-transform: scale(1);
     transform: scale(1); } }
-@keyframes appear {
+@keyframes $animation-name {
   0% {
     opacity: 0;
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     -ms-transform: scale(0);
     transform: scale(0); }
-
   100% {
     opacity: 1;
     -webkit-transform: scale(1);
@@ -444,55 +584,49 @@ hr {
   -moz-animation-fill-mode: backwards;
   animation-fill-mode: backwards; }
 
-@-webkit-keyframes pop {
+@-webkit-keyframes $animation-name {
   0% {
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     -ms-transform: scale(0);
     transform: scale(0); }
-
   50% {
     -webkit-transform: scale(1.2);
     -moz-transform: scale(1.2);
     -ms-transform: scale(1.2);
     transform: scale(1.2); }
-
   100% {
     -webkit-transform: scale(1);
     -moz-transform: scale(1);
     -ms-transform: scale(1);
     transform: scale(1); } }
-@-moz-keyframes pop {
+@-moz-keyframes $animation-name {
   0% {
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     -ms-transform: scale(0);
     transform: scale(0); }
-
   50% {
     -webkit-transform: scale(1.2);
     -moz-transform: scale(1.2);
     -ms-transform: scale(1.2);
     transform: scale(1.2); }
-
   100% {
     -webkit-transform: scale(1);
     -moz-transform: scale(1);
     -ms-transform: scale(1);
     transform: scale(1); } }
-@keyframes pop {
+@keyframes $animation-name {
   0% {
     -webkit-transform: scale(0);
     -moz-transform: scale(0);
     -ms-transform: scale(0);
     transform: scale(0); }
-
   50% {
     -webkit-transform: scale(1.2);
     -moz-transform: scale(1.2);
     -ms-transform: scale(1.2);
     transform: scale(1.2); }
-
   100% {
     -webkit-transform: scale(1);
     -moz-transform: scale(1);
@@ -516,6 +650,14 @@ hr {
   float: left;
   line-height: 42px;
   margin-bottom: 0; }
+  @media screen and (max-width: 520px) {
+    .game-intro {
+      width: 55%;
+      display: block;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      line-height: 1.65; } }
 
 .restart-button {
   display: inline-block;
@@ -529,230 +671,17 @@ hr {
   display: block;
   text-align: center;
   float: right; }
+  @media screen and (max-width: 520px) {
+    .restart-button {
+      width: 42%;
+      padding: 0;
+      display: block;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      margin-top: 2px; } }
 
 .game-explanation {
   margin-top: 50px; }
 
-@media screen and (max-width: 520px) {
-  html, body {
-    font-size: 15px; }
-
-  body {
-    margin: 20px 0;
-    padding: 0 20px; }
-
-  h1.title {
-    font-size: 27px;
-    margin-top: 15px; }
-
-  .container {
-    width: 280px;
-    margin: 0 auto; }
-
-  .score-container, .best-container {
-    margin-top: 0;
-    padding: 15px 10px;
-    min-width: 40px; }
-
-  .heading {
-    margin-bottom: 10px; }
-
-  .game-intro {
-    width: 55%;
-    display: block;
-    box-sizing: border-box;
-    line-height: 1.65; }
-
-  .restart-button {
-    width: 42%;
-    padding: 0;
-    display: block;
-    box-sizing: border-box;
-    margin-top: 2px; }
-
-  .game-container {
-    margin-top: 17px;
-    position: relative;
-    padding: 10px;
-    cursor: default;
-    -webkit-touch-callout: none;
-    -ms-touch-callout: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -ms-touch-action: none;
-    touch-action: none;
-    background: #bbada0;
-    border-radius: 6px;
-    width: 280px;
-    height: 280px;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box; }
-    .game-container .game-message {
-      display: none;
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      background: rgba(238, 228, 218, 0.5);
-      z-index: 100;
-      text-align: center;
-      -webkit-animation: fade-in 800ms ease 1200ms;
-      -moz-animation: fade-in 800ms ease 1200ms;
-      animation: fade-in 800ms ease 1200ms;
-      -webkit-animation-fill-mode: both;
-      -moz-animation-fill-mode: both;
-      animation-fill-mode: both; }
-      .game-container .game-message p {
-        font-size: 60px;
-        font-weight: bold;
-        height: 60px;
-        line-height: 60px;
-        margin-top: 222px; }
-      .game-container .game-message .lower {
-        display: block;
-        margin-top: 59px; }
-      .game-container .game-message a {
-        display: inline-block;
-        background: #8f7a66;
-        border-radius: 3px;
-        padding: 0 20px;
-        text-decoration: none;
-        color: #f9f6f2;
-        height: 40px;
-        line-height: 42px;
-        margin-left: 9px; }
-        .game-container .game-message a.keep-playing-button {
-          display: none; }
-      .game-container .game-message.game-won {
-        background: rgba(237, 194, 46, 0.5);
-        color: #f9f6f2; }
-        .game-container .game-message.game-won a.keep-playing-button {
-          display: inline-block; }
-      .game-container .game-message.game-won, .game-container .game-message.game-over {
-        display: block; }
-
-  .grid-container {
-    position: absolute;
-    z-index: 1; }
-
-  .grid-row {
-    margin-bottom: 10px; }
-    .grid-row:last-child {
-      margin-bottom: 0; }
-    .grid-row:after {
-      content: "";
-      display: block;
-      clear: both; }
-
-  .grid-cell {
-    width: 57.5px;
-    height: 57.5px;
-    margin-right: 10px;
-    float: left;
-    border-radius: 3px;
-    background: rgba(238, 228, 218, 0.35); }
-    .grid-cell:last-child {
-      margin-right: 0; }
-
-  .tile-container {
-    position: absolute;
-    z-index: 2; }
-
-  .tile, .tile .tile-inner {
-    width: 58px;
-    height: 58px;
-    line-height: 58px; }
-  .tile.tile-position-1-1 {
-    -webkit-transform: translate(0px, 0px);
-    -moz-transform: translate(0px, 0px);
-    -ms-transform: translate(0px, 0px);
-    transform: translate(0px, 0px); }
-  .tile.tile-position-1-2 {
-    -webkit-transform: translate(0px, 67px);
-    -moz-transform: translate(0px, 67px);
-    -ms-transform: translate(0px, 67px);
-    transform: translate(0px, 67px); }
-  .tile.tile-position-1-3 {
-    -webkit-transform: translate(0px, 135px);
-    -moz-transform: translate(0px, 135px);
-    -ms-transform: translate(0px, 135px);
-    transform: translate(0px, 135px); }
-  .tile.tile-position-1-4 {
-    -webkit-transform: translate(0px, 202px);
-    -moz-transform: translate(0px, 202px);
-    -ms-transform: translate(0px, 202px);
-    transform: translate(0px, 202px); }
-  .tile.tile-position-2-1 {
-    -webkit-transform: translate(67px, 0px);
-    -moz-transform: translate(67px, 0px);
-    -ms-transform: translate(67px, 0px);
-    transform: translate(67px, 0px); }
-  .tile.tile-position-2-2 {
-    -webkit-transform: translate(67px, 67px);
-    -moz-transform: translate(67px, 67px);
-    -ms-transform: translate(67px, 67px);
-    transform: translate(67px, 67px); }
-  .tile.tile-position-2-3 {
-    -webkit-transform: translate(67px, 135px);
-    -moz-transform: translate(67px, 135px);
-    -ms-transform: translate(67px, 135px);
-    transform: translate(67px, 135px); }
-  .tile.tile-position-2-4 {
-    -webkit-transform: translate(67px, 202px);
-    -moz-transform: translate(67px, 202px);
-    -ms-transform: translate(67px, 202px);
-    transform: translate(67px, 202px); }
-  .tile.tile-position-3-1 {
-    -webkit-transform: translate(135px, 0px);
-    -moz-transform: translate(135px, 0px);
-    -ms-transform: translate(135px, 0px);
-    transform: translate(135px, 0px); }
-  .tile.tile-position-3-2 {
-    -webkit-transform: translate(135px, 67px);
-    -moz-transform: translate(135px, 67px);
-    -ms-transform: translate(135px, 67px);
-    transform: translate(135px, 67px); }
-  .tile.tile-position-3-3 {
-    -webkit-transform: translate(135px, 135px);
-    -moz-transform: translate(135px, 135px);
-    -ms-transform: translate(135px, 135px);
-    transform: translate(135px, 135px); }
-  .tile.tile-position-3-4 {
-    -webkit-transform: translate(135px, 202px);
-    -moz-transform: translate(135px, 202px);
-    -ms-transform: translate(135px, 202px);
-    transform: translate(135px, 202px); }
-  .tile.tile-position-4-1 {
-    -webkit-transform: translate(202px, 0px);
-    -moz-transform: translate(202px, 0px);
-    -ms-transform: translate(202px, 0px);
-    transform: translate(202px, 0px); }
-  .tile.tile-position-4-2 {
-    -webkit-transform: translate(202px, 67px);
-    -moz-transform: translate(202px, 67px);
-    -ms-transform: translate(202px, 67px);
-    transform: translate(202px, 67px); }
-  .tile.tile-position-4-3 {
-    -webkit-transform: translate(202px, 135px);
-    -moz-transform: translate(202px, 135px);
-    -ms-transform: translate(202px, 135px);
-    transform: translate(202px, 135px); }
-  .tile.tile-position-4-4 {
-    -webkit-transform: translate(202px, 202px);
-    -moz-transform: translate(202px, 202px);
-    -ms-transform: translate(202px, 202px);
-    transform: translate(202px, 202px); }
-
-  .tile .tile-inner {
-    font-size: 35px; }
-
-  .game-message p {
-    font-size: 30px !important;
-    height: 30px !important;
-    line-height: 30px !important;
-    margin-top: 90px !important; }
-  .game-message .lower {
-    margin-top: 30px !important; } }
+/*# sourceMappingURL=main.css.map */

--- a/style/main.scss
+++ b/style/main.scss
@@ -2,9 +2,12 @@
 @import "fonts/clear-sans.css";
 
 $field-width: 500px;
+$field-width-smaller: 280px;
 $grid-spacing: 15px;
+$grid-spacing-smaller: 10px;
 $grid-row-cells: 4;
 $tile-size: ($field-width - $grid-spacing * ($grid-row-cells + 1)) / $grid-row-cells;
+$tile-size-smaller: ($field-width-smaller - $grid-spacing-smaller * ($grid-row-cells + 1)) / $grid-row-cells;
 $tile-border-radius: 3px;
 
 $mobile-threshold: $field-width + 20px;
@@ -17,6 +20,7 @@ $tile-gold-color: #edc22e;
 $tile-gold-glow-color: lighten($tile-gold-color, 15%);
 
 $game-container-margin-top: 40px;
+$game-container-margin-top-smaller: 17px;
 $game-container-background: #bbada0;
 
 $transition-speed: 100ms;
@@ -29,14 +33,26 @@ html, body {
   color: $text-color;
   font-family: "Clear Sans", "Helvetica Neue", Arial, sans-serif;
   font-size: 18px;
+  @include smaller($mobile-threshold) {
+    font-size: 15px;
+  }
 }
 
 body {
   margin: 80px 0;
+  @include smaller($mobile-threshold) {
+    margin: 20px 0;
+    padding: 0 20px;
+  }
+
+
 }
 
 .heading {
   @include clearfix;
+  @include smaller($mobile-threshold) {
+    margin-bottom: 10px;
+  }
 }
 
 h1.title {
@@ -45,6 +61,12 @@ h1.title {
   margin: 0;
   display: block;
   float: left;
+  @include smaller($mobile-threshold) {
+    font-size: 27px;
+    margin-top: 15px;
+  }
+
+
 }
 
 @include keyframes(move-up) {
@@ -79,6 +101,12 @@ h1.title {
   color: white;
   margin-top: 8px;
   text-align: center;
+
+  @include smaller($mobile-threshold) {
+    margin-top: 0;
+    padding: 15px 10px;
+    min-width: 40px;
+  }
 
   &:after {
     position: absolute;
@@ -142,6 +170,9 @@ hr {
 
 .container {
   width: $field-width;
+  @include smaller($mobile-threshold) {
+    width: $field-width-smaller
+  }
   margin: 0 auto;
 }
 
@@ -167,8 +198,6 @@ hr {
   line-height: 42px;
 }
 
-// Game field mixin used to render CSS at different width
-@mixin game-field {
   .game-container {
     margin-top: $game-container-margin-top;
     position: relative;
@@ -189,9 +218,13 @@ hr {
     border-radius: $tile-border-radius * 2;
     width: $field-width;
     height: $field-width;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
+    @include smaller($mobile-threshold) {
+      margin-top: $game-container-margin-top-smaller;
+      padding: $grid-spacing-smaller;
+      width: $field-width-smaller;
+      height: $field-width-smaller;
+    }
+    @include boxsize (border-box);
 
     .game-message {
       display: none;
@@ -214,11 +247,21 @@ hr {
         margin-top: 222px;
         // height: $field-width;
         // line-height: $field-width;
+
+        @include smaller($mobile-threshold) {
+          font-size: 30px !important;
+          height: 30px !important;
+          line-height: 30px !important;
+          margin-top: 90px !important;
+        }
       }
 
       .lower {
         display: block;
         margin-top: 59px;
+        @include smaller($mobile-threshold) {
+          margin-top: 30px !important;
+        }
       }
 
       a {
@@ -256,6 +299,9 @@ hr {
 
   .grid-row {
     margin-bottom: $grid-spacing;
+    @include smaller($mobile-threshold) {
+      margin-bottom: $grid-spacing-smaller;
+    }
 
     &:last-child {
       margin-bottom: 0;
@@ -272,6 +318,11 @@ hr {
     width: $tile-size;
     height: $tile-size;
     margin-right: $grid-spacing;
+    @include smaller($mobile-threshold) {
+      width: $tile-size-smaller;
+      height: $tile-size-smaller;
+      margin-right: $grid-spacing-smaller;
+    }
     float: left;
 
     border-radius: $tile-border-radius;
@@ -293,6 +344,11 @@ hr {
       width: ceil($tile-size);
       height: ceil($tile-size);
       line-height: ceil($tile-size);
+      @include smaller($mobile-threshold) {
+        width: ceil($tile-size-smaller);
+        height: ceil($tile-size-smaller);
+        line-height: ceil($tile-size-smaller);
+      }
     }
 
     // Build position classes
@@ -302,14 +358,15 @@ hr {
           $xPos: floor(($tile-size + $grid-spacing) * ($x - 1));
           $yPos: floor(($tile-size + $grid-spacing) * ($y - 1));
           @include transform(translate($xPos, $yPos));
+          @include smaller($mobile-threshold) {
+            $xPos-smaller: floor(($tile-size-smaller + $grid-spacing-smaller) * ($x - 1));
+            $yPos-smaller: floor(($tile-size-smaller + $grid-spacing-smaller) * ($y - 1));
+            @include transform(translate($xPos-smaller, $yPos-smaller));
+          }
         }
       }
     }
   }
-}
-
-// End of game-field mixin
-@include game-field;
 
 .tile {
   position: absolute; // Makes transforms relative to the top-left corner
@@ -323,6 +380,9 @@ hr {
     z-index: 10;
 
     font-size: 55px;
+    @include smaller($mobile-threshold) {
+      font-size: 35px;
+    }
   }
 
   // Movement transition
@@ -459,6 +519,14 @@ hr {
   float: left;
   line-height: 42px;
   margin-bottom: 0;
+
+  // Show intro and restart button side by side
+  @include smaller($mobile-threshold) {
+    width: 55%;
+    display: block;
+    @include boxsize(border-box);
+    line-height: 1.65;
+  }
 }
 
 .restart-button {
@@ -466,84 +534,15 @@ hr {
   display: block;
   text-align: center;
   float: right;
+  @include smaller($mobile-threshold) {
+    width: 42%;
+    padding: 0;
+    display: block;
+    @include boxsize(border-box);
+    margin-top: 2px;
+  }
 }
 
 .game-explanation {
   margin-top: 50px;
-}
-
-@include smaller($mobile-threshold) {
-  // Redefine variables for smaller screens
-  $field-width: 280px;
-  $grid-spacing: 10px;
-  $grid-row-cells: 4;
-  $tile-size: ($field-width - $grid-spacing * ($grid-row-cells + 1)) / $grid-row-cells;
-  $tile-border-radius: 3px;
-  $game-container-margin-top: 17px;
-
-  html, body {
-    font-size: 15px;
-  }
-
-  body {
-    margin: 20px 0;
-    padding: 0 20px;
-  }
-
-  h1.title {
-    font-size: 27px;
-    margin-top: 15px;
-  }
-
-  .container {
-    width: $field-width;
-    margin: 0 auto;
-  }
-
-  .score-container, .best-container {
-    margin-top: 0;
-    padding: 15px 10px;
-    min-width: 40px;
-  }
-
-  .heading {
-    margin-bottom: 10px;
-  }
-
-  // Show intro and restart button side by side
-  .game-intro {
-    width: 55%;
-    display: block;
-    box-sizing: border-box;
-    line-height: 1.65;
-  }
-
-  .restart-button {
-    width: 42%;
-    padding: 0;
-    display: block;
-    box-sizing: border-box;
-    margin-top: 2px;
-  }
-
-  // Render the game field at the right width
-  @include game-field;
-
-  // Rest of the font-size adjustments in the tile class
-  .tile .tile-inner {
-    font-size: 35px;
-  }
-
-  .game-message {
-    p {
-      font-size: 30px !important;
-      height: 30px !important;
-      line-height: 30px !important;
-      margin-top: 90px !important;
-    }
-
-    .lower {
-      margin-top: 30px !important;
-    }
-  }
 }


### PR DESCRIPTION
Boiled down the redundant definitions in main.scss so that (for example) .container is defined in just one place, with only a couple lines enhanced by the smaller mixin. Also fixed the issue with tile sizes not being small when the board was small. Also moved the generation of the cells into Javascript to benefit anyone who is playing with the number of rows and columns. Some of the code (especially in main.scss) is not perfectly indented yet.