### PR TITLE
Add Service Worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,9 @@
   <script src="js/application.js"></script>
   <script>
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/serviceworker.js');
+      navigator.serviceWorker.register('/serviceworker.js', {
+        scope: './'
+      });
     }
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -95,5 +95,10 @@
   <script src="js/local_storage_manager.js"></script>
   <script src="js/game_manager.js"></script>
   <script src="js/application.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/serviceworker.js');
+    }
+  </script>
 </body>
 </html>

--- a/serviceworker.js
+++ b/serviceworker.js
@@ -2,23 +2,25 @@ const VERSION = '1';
 
 const CACHE_URLS = [
   '/',
-  '/style/main.css',
-  '/js/bind_polyfill.js',
-  '/js/classlist_polyfill.js',
-  '/js/animframe_polyfill.js',
-  '/js/keyboard_input_manager.js',
-  '/js/html_actuator.js',
-  '/js/grid.js',
-  '/js/tile.js',
-  '/js/local_storage_manager.js',
-  '/js/game_manager.js',
-  '/js/application.js',
+  'style/main.css',
+  'js/bind_polyfill.js',
+  'js/classlist_polyfill.js',
+  'js/animframe_polyfill.js',
+  'js/keyboard_input_manager.js',
+  'js/html_actuator.js',
+  'js/grid.js',
+  'js/tile.js',
+  'js/local_storage_manager.js',
+  'js/game_manager.js',
+  'js/application.js',
 ];
 
 const OPTIONAL_CACHE_URLS = [
-  '/style/fonts/clear-sans.css',
-  '/style/fonts/ClearSans-Regular-webfont.woff',
-  '/style/fonts/ClearSans-Bold-webfont.woff'
+  'style/fonts/clear-sans.css',
+  'style/fonts/ClearSans-Regular-webfont.woff',
+  'style/fonts/ClearSans-Bold-webfont.woff',
+  'icon_pp.svg',
+  'icon_bitcoin.svg'
 ];
 
 function deleteOldCaches(keys) {
@@ -26,8 +28,7 @@ function deleteOldCaches(keys) {
     keys
       .filter(key => key !== VERSION)
       .map(key => caches.delete(key))
-  )
-  .catch(console.log);
+  );
 }
 
 self.addEventListener('install', event => {
@@ -36,7 +37,6 @@ self.addEventListener('install', event => {
       cache.addAll(OPTIONAL_CACHE_URLS);
       return cache.addAll(CACHE_URLS);
     })
-    .catch(console.log)
   );
 });
 

--- a/serviceworker.js
+++ b/serviceworker.js
@@ -1,0 +1,55 @@
+const VERSION = '1.2';
+
+const CACHE_URLS = [
+  '/',
+  '/style/main.css',
+  '/js/bind_polyfill.js',
+  '/js/classlist_polyfill.js',
+  '/js/animframe_polyfill.js',
+  '/js/keyboard_input_manager.js',
+  '/js/html_actuator.js',
+  '/js/grid.js',
+  '/js/tile.js',
+  '/js/local_storage_manager.js',
+  '/js/game_manager.js',
+  '/js/application.js',
+];
+
+const OPTIONAL_CACHE_URLS = [
+  '/style/fonts/clear-sans.css',
+  '/style/fonts/ClearSans-Regular-webfont.woff',
+  '/style/fonts/ClearSans-Bold-webfont.woff'
+];
+
+function deleteOldCaches(keys) {
+  return Promise.all(
+    keys
+      .filter(key => key !== VERSION)
+      .map(key => caches.delete(key))
+  )
+  .catch(console.log);
+}
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(VERSION).then(cache => {
+      cache.addAll(OPTIONAL_CACHE_URLS);
+      return cache.addAll(CACHE_URLS);
+    })
+    .catch(console.log)
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(deleteOldCaches)
+  )
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});

--- a/serviceworker.js
+++ b/serviceworker.js
@@ -1,4 +1,4 @@
-const VERSION = '1.2';
+const VERSION = '1';
 
 const CACHE_URLS = [
   '/',


### PR DESCRIPTION
### Context

The AppCache API is being [deprecated](https://html.spec.whatwg.org/multipage/browsers.html#offline) in favour of the [Service Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API).

The advantage of SW over AppCache is that it provides more fine-grained control over how caching is done, and how to go about deleting old caches.
### What it does

This PR adds a Service Worker that implements caching of resources. The `index.html`, `main.css` and all the JavaScript files are always cached. If the SW fails to cache any of these, it will fail to install.

Optionally, it will also try to cache the webfonts, but a failure to fetch those won't hinder the installation of the SW.

Once the SW is installed, the browser will load every resource from the cache if available, falling back to the network if it isn't.
### How to update content

Should you decide to merge this, every change in HTML/CSS/JS will also require a change in the SW. This is as simple as incrementing the `VERSION` constant in `serviceworker.js`, line 1. If this version is not changed, people using a cached version will never receive the updated resource.
### Further info about SW API
- [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)
- [HTML5Rocks article](http://www.html5rocks.com/en/tutorials/service-worker/introduction/)
- [Browser support](https://jakearchibald.github.io/isserviceworkerready/)
#### Note on ES6 features

I have taken the liberty to use some ES6 features in `serviceworker.js`. While these features lack widespread browser support, it so happens that the browsers that support SW also support these features, so it is safe to use them.
