### PR TITLE
Update bind_polyfill.js

### DIFF
--- a/js/bind_polyfill.js
+++ b/js/bind_polyfill.js
@@ -4,6 +4,6 @@ Function.prototype.bind = Function.prototype.bind || function (target) {
     if (!(args instanceof Array)) {
       args = [args];
     }
-    self.apply(target, args);
+    return self.apply(target, args);
   };
 };


### PR DESCRIPTION
Bind polyfill function lost "return".So it won't work well if the browser doesn't support raw bind function.