### PR TITLE
Call window.localStorage moved into try catch

### DIFF
--- a/js/local_storage_manager.js
+++ b/js/local_storage_manager.js
@@ -28,9 +28,9 @@ function LocalStorageManager() {
 
 LocalStorageManager.prototype.localStorageSupported = function () {
   var testKey = "test";
-  var storage = window.localStorage;
 
   try {
+    var storage = window.localStorage;
     storage.setItem(testKey, "1");
     storage.removeItem(testKey);
     return true;


### PR DESCRIPTION
window.localStorage can throw exception in Edge browser. So its now inside try catch block of function localStorageSupported.