### PR TITLE
Extended tile colors + mobile responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,20 +3,71 @@
 <head>
   <meta charset="utf-8">
   <title>2048</title>
-
   <link href="style/main.css" rel="stylesheet" type="text/css">
   <link rel="shortcut icon" href="favicon.ico">
   <link rel="apple-touch-icon" href="meta/apple-touch-icon.png">
-  <link rel="apple-touch-startup-image" href="meta/apple-touch-startup-image-640x1096.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)"> <!-- iPhone 5+ -->
-  <link rel="apple-touch-startup-image" href="meta/apple-touch-startup-image-640x920.png"  media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 2)"> <!-- iPhone, retina -->
+  <link rel="apple-touch-startup-image" href="meta/apple-touch-startup-image-640x1096.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)">
+  <link rel="apple-touch-startup-image" href="meta/apple-touch-startup-image-640x920.png"  media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 2)">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-
   <meta name="HandheldFriendly" content="True">
-  <meta name="MobileOptimized" content="320">
-  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0, maximum-scale=1, user-scalable=no, minimal-ui">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no, minimal-ui">
+  <style>
+    /* Scale wrapper — только для мобильных, десктоп не трогаем */
+    #scale-wrapper { transform-origin: top center; }
+    @media screen and (max-width: 520px) { body { overflow-x: hidden; padding: 0 8px !important; } }
+
+    /* Мобильные правки поверх main.css */
+    @media screen and (max-width: 520px) {
+      /* Intro text меньше */
+      .game-intro {
+        font-size: 13px;
+        line-height: 1.3;
+        width: 52%;
+      }
+      /* New Game кнопка уже */
+      .restart-button {
+        width: 44%;
+        font-size: 13px;
+        padding: 0;
+        text-align: center;
+      }
+      /* Всё что ниже игры — скрыть */
+      .game-explanation, hr, p:not(.game-intro):not(.game-message p) {
+        display: none;
+      }
+      /* Кнопка Rules */
+      #rules-btn {
+        display: block;
+        margin-top: 14px;
+        background: none;
+        border: 1px solid #bbada0;
+        color: #776e65;
+        font-size: 13px;
+        padding: 5px 16px;
+        border-radius: 3px;
+        cursor: pointer;
+        font-family: inherit;
+        width: 100%;
+        text-align: center;
+      }
+      #rules-full {
+        display: none;
+        margin-top: 10px;
+        font-size: 13px;
+        line-height: 1.6;
+        color: #776e65;
+      }
+    }
+    /* На десктопе кнопку Rules скрыть */
+    @media screen and (min-width: 521px) {
+      #rules-btn { display: none; }
+      #rules-full { display: block; }
+    }
+  </style>
 </head>
 <body>
+  <div id="scale-wrapper">
   <div class="container">
     <div class="heading">
       <h1 class="title">2048</h1>
@@ -35,54 +86,51 @@
       <div class="game-message">
         <p></p>
         <div class="lower">
-	        <a class="keep-playing-button">Keep going</a>
+          <a class="keep-playing-button">Keep going</a>
           <a class="retry-button">Try again</a>
         </div>
       </div>
-
       <div class="grid-container">
         <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
+          <div class="grid-cell"></div><div class="grid-cell"></div>
+          <div class="grid-cell"></div><div class="grid-cell"></div>
         </div>
         <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
+          <div class="grid-cell"></div><div class="grid-cell"></div>
+          <div class="grid-cell"></div><div class="grid-cell"></div>
         </div>
         <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
+          <div class="grid-cell"></div><div class="grid-cell"></div>
+          <div class="grid-cell"></div><div class="grid-cell"></div>
         </div>
         <div class="grid-row">
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
-          <div class="grid-cell"></div>
+          <div class="grid-cell"></div><div class="grid-cell"></div>
+          <div class="grid-cell"></div><div class="grid-cell"></div>
         </div>
       </div>
-
-      <div class="tile-container">
-
-      </div>
+      <div class="tile-container"></div>
     </div>
 
-    <p class="game-explanation">
-      <strong class="important">How to play:</strong> Use your <strong>arrow keys</strong> to move the tiles. When two tiles with the same number touch, they <strong>merge into one!</strong>
-    </p>
-    <hr>
-    <p>
-    <strong class="important">Note:</strong> This site is the official version of 2048. You can play it on your phone via <a href="http://git.io/2048">http://git.io/2048.</a> All other apps or sites are derivatives or fakes, and should be used with caution.
-    </p>
-    <hr>
-    <p>
-    Created by <a href="http://gabrielecirulli.com" target="_blank">Gabriele Cirulli.</a> Based on <a href="https://itunes.apple.com/us/app/1024!/id823499224" target="_blank">1024 by Veewo Studio</a> and conceptually similar to <a href="http://asherv.com/threes/" target="_blank">Threes by Asher Vollmer.</a>
-    </p>
+    <!-- Кнопка Rules — только на мобильных -->
+    <button id="rules-btn" onclick="toggleRules()">&#9660; Rules</button>
+
+    <!-- Полный текст — на десктопе всегда, на мобиле под кнопкой -->
+    <div id="rules-full">
+      <p class="game-explanation">
+        <strong class="important">How to play:</strong> Use your <strong>arrow keys</strong>
+        to move the tiles. When two tiles with the same number touch,
+        they <strong>merge into one!</strong>
+      </p>
+      <hr>
+      <p>
+        Created by <a href="http://gabrielecirulli.com" target="_blank">Gabriele Cirulli.</a>
+        Based on <a href="https://itunes.apple.com/us/app/1024!/id823499224" target="_blank">1024 by Veewo Studio</a>
+        and conceptually similar to <a href="http://asherv.com/threes/" target="_blank">Threes by Asher Vollmer.</a>
+        Licensed under the <a href="LICENSE.txt">MIT License.</a>
+      </p>
+    </div>
+
+  </div>
   </div>
 
   <script src="js/bind_polyfill.js"></script>
@@ -95,5 +143,41 @@
   <script src="js/local_storage_manager.js"></script>
   <script src="js/game_manager.js"></script>
   <script src="js/application.js"></script>
+
+  <script>
+    function toggleRules() {
+      var full = document.getElementById('rules-full');
+      var btn  = document.getElementById('rules-btn');
+      if (full.style.display === 'none' || full.style.display === '') {
+        full.style.display = 'block';
+        btn.innerHTML = '&#9650; Rules';
+      } else {
+        full.style.display = 'none';
+        btn.innerHTML = '&#9660; Rules';
+      }
+    }
+
+    function scaleGame() {
+      var wrapper = document.getElementById('scale-wrapper');
+      wrapper.style.transform = '';
+      wrapper.style.marginBottom = '';
+
+      if (window.innerWidth >= 521) return; // десктоп — не трогаем
+
+      var container = document.querySelector('.container');
+      var naturalWidth = container.offsetWidth;
+      var available = window.innerWidth - 16;
+      var scale = available / naturalWidth;
+
+      if (scale !== 1) {
+        wrapper.style.transform = 'scale(' + scale + ')';
+        wrapper.style.transformOrigin = 'top center';
+        wrapper.style.marginBottom = Math.round(wrapper.offsetHeight * (scale - 1)) + 'px';
+      }
+    }
+
+    window.addEventListener('load', scaleGame);
+    window.addEventListener('resize', scaleGame);
+  </script>
 </body>
 </html>

--- a/style/main.css
+++ b/style/main.css
@@ -756,3 +756,52 @@ hr {
     margin-top: 90px !important; }
   .game-message .lower {
     margin-top: 30px !important; } }
+
+/* Extended tile colors for values above 2048 */
+.tile.tile-4096 .tile-inner {
+  color: #f9f6f2;
+  background: #b784a7;
+  box-shadow: 0 0 30px 10px rgba(183, 132, 167, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+  font-size: 30px; }
+  @media screen and (max-width: 520px) {
+    .tile.tile-4096 .tile-inner { font-size: 10px; } }
+
+.tile.tile-8192 .tile-inner {
+  color: #f9f6f2;
+  background: #7b5ea7;
+  box-shadow: 0 0 30px 10px rgba(123, 94, 167, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+  font-size: 30px; }
+  @media screen and (max-width: 520px) {
+    .tile.tile-8192 .tile-inner { font-size: 10px; } }
+
+.tile.tile-16384 .tile-inner {
+  color: #f9f6f2;
+  background: #4a90d9;
+  box-shadow: 0 0 30px 10px rgba(74, 144, 217, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+  font-size: 25px; }
+  @media screen and (max-width: 520px) {
+    .tile.tile-16384 .tile-inner { font-size: 8px; } }
+
+.tile.tile-32768 .tile-inner {
+  color: #f9f6f2;
+  background: #2ecc71;
+  box-shadow: 0 0 30px 10px rgba(46, 204, 113, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+  font-size: 25px; }
+  @media screen and (max-width: 520px) {
+    .tile.tile-32768 .tile-inner { font-size: 8px; } }
+
+.tile.tile-65536 .tile-inner {
+  color: #f9f6f2;
+  background: #e74c3c;
+  box-shadow: 0 0 30px 10px rgba(231, 76, 60, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+  font-size: 20px; }
+  @media screen and (max-width: 520px) {
+    .tile.tile-65536 .tile-inner { font-size: 7px; } }
+
+.tile.tile-131072 .tile-inner {
+  color: #f9f6f2;
+  background: linear-gradient(135deg, #f39c12, #e74c3c, #9b59b6);
+  box-shadow: 0 0 40px 15px rgba(243, 156, 18, 0.6), inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+  font-size: 18px; }
+  @media screen and (max-width: 520px) {
+    .tile.tile-131072 .tile-inner { font-size: 6px; } }


### PR DESCRIPTION
Extended tile colors for values above 2048 (works on all devices):
- 4096: mauve (#b784a7)
- 8192: purple (#7b5ea7)
- 16384: blue (#4a90d9)
- 32768: green (#2ecc71)
- 65536: red (#e74c3c)
- 131072: rainbow gradient (#f39c12 → #e74c3c → #9b59b6)
  (theoretical maximum — unreachable in standard play,
  but why leave it black when it could be beautiful?)

Mobile responsive improvements:
- CSS scale wrapper fits game to any screen width on mobile
- Collapsible rules text below game (▼ Rules button) on mobile
- 8px side padding on mobile for clean look
- Desktop layout and gameplay completely unchanged